### PR TITLE
Add parenthesis for order of operations clarity

### DIFF
--- a/src/bin/simple.rs
+++ b/src/bin/simple.rs
@@ -33,7 +33,7 @@ fn handle_connection(mut connection: TcpStream) -> io::Result<()> {
         read += num_bytes;
 
         // have we reached the end of the request?
-        if request.get(read - 4..read) == Some(b"\r\n\r\n") {
+        if request.get((read - 4)..read) == Some(b"\r\n\r\n") {
             break;
         }
     }


### PR DESCRIPTION
Came across your blog post thanks to Rust Lang News, and I wanted to say that I loved it! Thank you for your contributing to the Rust community, especially on a topic that can be as confusing as `async`.

It took me a while to understand [this line](https://github.com/ibraheemdev/too-many-web-servers/blob/master/src/bin/simple.rs#L36) in `simple.rs` until I realized the order of operations for the range operator. I wanted to put up this PR to make the order of operations more explicit, in case other people were confused like me.

Thank you again 😄  